### PR TITLE
WIP Codex  - a tool for AST conversion

### DIFF
--- a/projects/codex/.eslintrc
+++ b/projects/codex/.eslintrc
@@ -1,0 +1,1 @@
+extends: eslint-config-sorcerers

--- a/projects/codex/babel.config.js
+++ b/projects/codex/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [`@babel/preset-env`],
+  plugins: [
+    `@babel/plugin-transform-destructuring`,
+    `@babel/plugin-proposal-object-rest-spread`
+  ]
+}

--- a/projects/codex/fixture/sre-node-input.js
+++ b/projects/codex/fixture/sre-node-input.js
@@ -1,0 +1,2 @@
+import SRE from "sre"
+const MyNode = Node(() => {})

--- a/projects/codex/fixture/sre-node-output.js
+++ b/projects/codex/fixture/sre-node-output.js
@@ -1,0 +1,2 @@
+import SRE from 'sre'
+const MyNode = () => {}

--- a/projects/codex/goal-api.js
+++ b/projects/codex/goal-api.js
@@ -1,0 +1,8 @@
+const codexPage = ({ AST, transform, find, propTypeIs, pipe, filter, is }) =>
+  pipe(
+    find(is(AST.Function)),
+    filter(propTypeIs("parent", AST.VariableDeclarator)),
+    transform(AST.callExpression(AST.identifier("Node")))
+  )
+
+export default codexPage

--- a/projects/codex/package-scripts.js
+++ b/projects/codex/package-scripts.js
@@ -1,0 +1,15 @@
+module.exports = {
+  scripts: {
+    build: {
+      script: "nps build.rollup build.cli",
+      rollup: "rollup -c rollup.config.js",
+      cli: "chmod 755 ./brainwave-cli.js"
+    },
+    lint: "eslint ./src --fix",
+    test: {
+      script: "jest --verbose --coverage ",
+      description: "run tests",
+      watch: "jest --verbose --coverage --watchAll"
+    }
+  }
+}

--- a/projects/codex/package.json
+++ b/projects/codex/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "codex",
+  "version": "0.0.0",
+  "description": "ast transformation from the future",
+  "main": "codex.js",
+  "repository": "https://github.com/open-sorcerers/codex",
+  "author": "brekk",
+  "license": "ISC",
+  "private": false,
+  "dependencies": {
+    "astravel": "^0.5.0",
+    "astring": "^1.4.3",
+    "fluture": "^12.3.1",
+    "ramda": "^0.27.0",
+    "zippa": "^0.3.1"
+  },
+  "devDependencies": {
+    "eslint": "^7.3.1",
+    "prettier": "^2.0.5",
+    "prettier-eslint": "^11.0.0"
+  }
+}


### PR DESCRIPTION
A Zipper(?) and Future(?) based tool for editing abstract syntax trees
Likely using some or all of the following:
 * `zippa`
 * `fluture`
 * `ramda`
 * `astring`
 * `astravel`

Candidate names (some might need to be moved to `open-sorcerers` if not available in the global npm namespace):
* *codex* - was imagining a book which clearly looks futuristic, time-machine feel
* *time-machine* - too generic, probably, but this magic forward <-> backward in time intent
* *the-right-way* - intentionally inflammatory :joy:
* *changeling*